### PR TITLE
feat: add noContract option flag to the make:service command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ and implements the `app/Services/Contracts/CreateUserContract.php` which is gene
 
 ## Contracts
 
-If you do not need any contract with your service. Then turn the **with_interface** value to false in the config file.
+If for a specific service you don't need a contract, you can add the `--noContract` option flag to the the command.
+
+If for some reason you do not need any contract with all your services, then turn the **with_interface** value to false in the config file.
 
 ## Installation
 

--- a/src/Commands/LaravelServiceMakerCommand.php
+++ b/src/Commands/LaravelServiceMakerCommand.php
@@ -9,7 +9,7 @@ class LaravelServiceMakerCommand extends Command
     /**
      * @var string
      */
-    protected $signature = 'make:service {name : The name of the service you want to create.}';
+    protected $signature = 'make:service {name : The name of the service you want to create.} {--noContract: Whether the service should have an interface.}';
 
     /**
      * @var string
@@ -23,11 +23,13 @@ class LaravelServiceMakerCommand extends Command
 
     public function handle(): int
     {
+        dd($this->option('noContract'));
         $this->call('make:servicefile', [
             'name' => $this->argument('name'),
+
         ]);
 
-        if (config('service-maker.with_interface')) {
+        if (config('service-maker.with_interface') || $this->option('noContract')) {
             $this->call('make:servicecontractfile', [
                 'name' => $this->argument('name'),
             ]);

--- a/src/Commands/LaravelServiceMakerCommand.php
+++ b/src/Commands/LaravelServiceMakerCommand.php
@@ -29,7 +29,7 @@ class LaravelServiceMakerCommand extends Command
 
         ]);
 
-        if (config('service-maker.with_interface') || $this->option('noContract')) {
+        if (config('service-maker.with_interface') || !$this->option('noContract')) {
             $this->call('make:servicecontractfile', [
                 'name' => $this->argument('name'),
             ]);


### PR DESCRIPTION
For now you can only create or not an interface class associated with the service class if the option `with_interface` is set to `true` in the config file. 

This PR add the ability to chose to not generate an Interface by adding a `--noContract` option flag to the command when the option `with_interface` is set to `true` in the config file.

The command look like:

```
php artisan make:service {name} {--noContract}
```

If the `--noContract` is not set in the command, the interface will be generated